### PR TITLE
Add warning to campaign form about reusing call in numbers

### DIFF
--- a/alembic/versions/38f01b0893b8_add_call_in_campaign_id_to_.py
+++ b/alembic/versions/38f01b0893b8_add_call_in_campaign_id_to_.py
@@ -1,0 +1,28 @@
+"""Add call_in_campaign_id to TwilioPhoneNumber
+
+Revision ID: 38f01b0893b8
+Revises: 3c34cfd19bf8
+Create Date: 2016-10-21 18:59:13.190060
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '38f01b0893b8'
+down_revision = '3c34cfd19bf8'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('campaign_phone') as batch_op:
+        batch_op.add_column(sa.Column('call_in_campaign_id',
+                                      sa.Integer(),
+                                      sa.ForeignKey('campaign_campaign.id'),
+                                      nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('campaign_phone') as batch_op:
+        batch_op.drop_column('call_in_campaign_id')

--- a/call_server/campaign/models.py
+++ b/call_server/campaign/models.py
@@ -217,7 +217,10 @@ class TwilioPhoneNumber(db.Model):
     twilio_sid = db.Column(db.String(TWILIO_SID_LENGTH))
     twilio_app = db.Column(db.String(TWILIO_SID_LENGTH))
     call_in_allowed = db.Column(db.Boolean, default=False)
+    call_in_campaign_id = db.Column(db.Integer, db.ForeignKey('campaign_campaign.id'))
     number = db.Column(phone_number.PhoneNumberType())
+
+    call_in_campaign = db.relationship('Campaign', foreign_keys=[call_in_campaign_id])
 
     def __unicode__(self):
         return self.number.__unicode__()
@@ -254,6 +257,7 @@ class TwilioPhoneNumber(db.Model):
         # set twilio number to use app
         twilio_client.phone_numbers.update(self.twilio_sid, voice_application_sid=app.sid)
         self.twilio_app = app.sid
+        self.call_in_campaign_id = campaign.id
 
         return success
 

--- a/call_server/static/scripts/site/campaign.js
+++ b/call_server/static/scripts/site/campaign.js
@@ -16,6 +16,10 @@
       // call limit
       'change input[name="call_limit"]': 'changeCallLimit',
 
+      // phone numbers
+      'change select#phone_number_set': 'checkForCallInCollisions',
+      'change input#allow_call_in': 'checkForCallInCollisions',
+
       'submit': 'submitForm'
     },
 
@@ -38,6 +42,15 @@
 
       // load existing items from hidden inputs
       this.targetListView.loadExistingItems();
+
+      $("#phone_number_set").parents(".controls").after(
+        $('<div id="call_in_collisions" class="panel alert-warning col-sm-4 hidden">').append(
+          "<p>This will override call in settings for these campaigns:</p>",
+          $("<ul>")
+        )
+      );
+
+      this.checkForCallInCollisions();
     },
 
     changeCampaignType: function() {
@@ -164,6 +177,23 @@
         callMaxGroup.hide();
         $('input[name="call_maximum"]').val('');
       }
+    },
+
+    checkForCallInCollisions: function(event) {
+      var collisions = [];
+      var taken = $("select#phone_number_set").data("call_in_map");
+      $("select#phone_number_set option:selected").each(function() {
+        if (taken[this.value] && collisions.indexOf(taken[this.value]) == -1)
+          collisions.push(taken[this.value]);
+      });
+
+      var list = $("#call_in_collisions ul").empty();
+      list.append($.map(collisions, function(name) { return $("<li>").text(name) }));
+
+      if ($("#allow_call_in").is(":checked") && collisions.length)
+        $("#call_in_collisions").removeClass("hidden");
+      else
+        $("#call_in_collisions").addClass("hidden");
     },
 
     validateNestedSelect: function(formGroup) {

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,7 +17,7 @@ MarkupSafe==0.18
 PyYAML==3.10
 SQLAlchemy==1.0.6
 SQLAlchemy-Utils==0.30.12
-WTForms==2.0.2
+WTForms==2.1
 WTForms-Components==0.9.7
 Werkzeug==0.10.4
 alembic==0.7.5.post2


### PR DESCRIPTION
This PR adds a warning to the edit page when a user selects for Call In a number which is already the call in number for a different campaign.

![callpower campaign](https://cloud.githubusercontent.com/assets/6469642/19612380/0942509e-979b-11e6-9956-477157d92d62.png)
