### PR TITLE
Initialize call_in_campaign_id column after adding

### DIFF
--- a/alembic/versions/38f01b0893b8_add_call_in_campaign_id_to_.py
+++ b/alembic/versions/38f01b0893b8_add_call_in_campaign_id_to_.py
@@ -23,6 +23,19 @@ def upgrade():
                                       sa.ForeignKey('campaign_campaign.id'),
                                       nullable=True))
 
+    connection = op.get_bind()
+    campaign_call_in_numbers = connection.execute(
+        """SELECT campaign_phone_numbers.campaign_id, campaign_phone_numbers.phone_id
+           FROM   campaign_phone_numbers
+           INNER JOIN campaign_phone ON campaign_phone_numbers.phone_id = campaign_phone.id
+           WHERE campaign_phone.call_in_allowed"""
+    )
+
+    for (campaign_id, phone_id) in campaign_call_in_numbers:
+        connection.execute("""UPDATE campaign_phone
+                              SET    call_in_campaign_id = """+str(campaign_id)+"""
+                              WHERE  campaign_phone.id = """+str(phone_id))
+
 def downgrade():
     with op.batch_alter_table('campaign_phone') as batch_op:
         batch_op.drop_column('call_in_campaign_id')


### PR DESCRIPTION
This fixes a problem that came up when I deployed recent changes. The migration call_in_campaign_id migration needs to initialize that column, otherwise [this line](https://github.com/EFForg/call-congress/blob/master/call_server/campaign/views.py#L61) will break the edit action.