### PR TITLE
Validate audio uploads

### DIFF
--- a/call_server/campaign/forms.py
+++ b/call_server/campaign/forms.py
@@ -92,6 +92,10 @@ class AudioRecordingForm(Form):
     text_to_speech = FileField(_('Text to Speech'), [Optional()])
     description = TextField(_('Description'), [Optional()])
 
+    def validate_file_storage(form, field):
+        if field.data and field.data.mimetype not in ["audio/mp3", "audio/wav"]:
+            raise ValidationError("File type must be mp3 or wav.")
+
 
 class CampaignLaunchForm(Form):
     next = HiddenField()

--- a/call_server/campaign/views.py
+++ b/call_server/campaign/views.py
@@ -20,6 +20,9 @@ from ..call.models import Call
 from .forms import (CampaignForm, CampaignAudioForm, AudioRecordingForm,
                     CampaignLaunchForm, CampaignStatusForm, TargetForm)
 
+from sndhdr import what
+import os
+
 campaign = Blueprint('campaign', __name__, url_prefix='/admin/campaign')
 
 
@@ -189,7 +192,9 @@ def upload_recording(campaign_id):
         # save uploaded file to storage
         file_storage = request.files.get('file_storage')
         if file_storage:
-            file_storage.filename = "campaign_{}_{}_{}.mp3".format(campaign.id, message_key, recording.version)
+            extension = "mp3" if file_storage.content_type == "audio/mp3" else "wav"
+            file_storage.filename = "campaign_{}_{}_{}.{}" \
+                .format(campaign.id, message_key, recording.version, extension)
             recording.file_storage = file_storage
         else:
             # dummy file storage

--- a/call_server/campaign/views.py
+++ b/call_server/campaign/views.py
@@ -20,9 +20,6 @@ from ..call.models import Call
 from .forms import (CampaignForm, CampaignAudioForm, AudioRecordingForm,
                     CampaignLaunchForm, CampaignStatusForm, TargetForm)
 
-from sndhdr import what
-import os
-
 campaign = Blueprint('campaign', __name__, url_prefix='/admin/campaign')
 
 

--- a/call_server/campaign/views.py
+++ b/call_server/campaign/views.py
@@ -189,7 +189,9 @@ def upload_recording(campaign_id):
         # save uploaded file to storage
         file_storage = request.files.get('file_storage')
         if file_storage:
-            extension = "mp3" if file_storage.mimetype == "audio/mp3" else "wav"
+            original_extension = "." in file_storage.filename and \
+                    file_storage.filename.rsplit('.', 1)[1].lower()
+            extension = original_extension or "mp3" # default to mp3, eg for uploaded blobs
             file_storage.filename = "campaign_{}_{}_{}.{}" \
                 .format(campaign.id, message_key, recording.version, extension)
             recording.file_storage = file_storage

--- a/call_server/campaign/views.py
+++ b/call_server/campaign/views.py
@@ -189,7 +189,7 @@ def upload_recording(campaign_id):
         # save uploaded file to storage
         file_storage = request.files.get('file_storage')
         if file_storage:
-            extension = "mp3" if file_storage.content_type == "audio/mp3" else "wav"
+            extension = "mp3" if file_storage.mimetype == "audio/mp3" else "wav"
             file_storage.filename = "campaign_{}_{}_{}.{}" \
                 .format(campaign.id, message_key, recording.version, extension)
             recording.file_storage = file_storage

--- a/call_server/static/scripts/site/microphone.js
+++ b/call_server/static/scripts/site/microphone.js
@@ -262,7 +262,6 @@
       return isValid;
     },
 
-
     validateForm: function() {
       var isValid = true;
       var self = this;
@@ -341,8 +340,10 @@
               self.saved = true;
               self.$el.modal('hide');
             } else {
-              console.error(response);
-              window.flashMessage(response.errors, 'error', true);
+              Object.keys(response.errors).forEach(field => {
+                var msg = response.errors[field];
+                self.validateField($('.tab-pane.active'), () => { false; }, msg);
+              });
             }
           },
           error: function(xhr, status, error) {

--- a/call_server/static/scripts/site/microphone.js
+++ b/call_server/static/scripts/site/microphone.js
@@ -253,7 +253,7 @@
       }
 
       var isValid = validator(parentGroup);
-      
+
       // put message in last help-block
       $('.help-block', parentGroup).last().text((!isValid) ? message : '');
 
@@ -298,7 +298,7 @@
       // submit file via ajax with html5 FormData
       // probably will not work in old IE
       var formData = new FormData();
-      
+
       // add inputs individually, so we can control how we add files
       var formItems = $('form.modal-body', this.$el).find('input[type!="file"], select, textarea');
       _.each(formItems, function(item) {

--- a/call_server/templates/campaign/microphone.html
+++ b/call_server/templates/campaign/microphone.html
@@ -82,7 +82,7 @@
                                     <br>
                                     <p class="help-text col-xs-12">
                                         <em>Please record your audio with another application and upload the file here.</em><br>
-                                        <a href="https://www.twilio.com/docs/api/twiml/play#nouns" target="_blank">Accepted filetypes</a> include mp3, wav, aiff, gsm, and &mu;-law.
+                                        <a href="https://www.twilio.com/docs/api/twiml/play#nouns" target="_blank">Accepted filetypes</a> are mp3 and wav.
                                     </p>
                                 </div>
                                 <div class="help-block"></div>

--- a/call_server/wsgi.py
+++ b/call_server/wsgi.py
@@ -2,8 +2,8 @@
 try:
     from gevent.monkey import patch_all
     patch_all()
-    import gevent_psycopg2
-    gevent_psycopg2.monkey_patch()
+    import psycogreen.gevent
+    psycogreen.gevent.patch_psycopg()
 except ImportError:
     print "unable to apply gevent monkey.patch_all"
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -32,6 +32,7 @@ phonenumbers==7.0.4
 pygeocodio==0.5.0
 pystache==0.5.3
 python-dateutil==2.2
+python-magic==0.4.15
 python-mimeparse==0.1.4
 pytz==2013.9
 requests==2.2.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,7 +1,7 @@
 -r common.txt
 boto==2.38.0
 gevent==1.1.1
-gevent-psycopg2==0.0.3
+psycogreen==1.0
 greenlet==0.4.10
 psycopg2==2.6.1
 redis==2.10.3


### PR DESCRIPTION
* Validates recordings and audio file uploads (they share a fields) by checking the mimetype attribute on the FileStorage object and calling Unix's `file` command.
* Migrates from gevent-psycopg to psycogreen. This was necessary to build the container - see commit message for details.

Resolves #19 