### PR TITLE
Fix mp3 uploads on Firefox

### DIFF
--- a/call_server/campaign/forms.py
+++ b/call_server/campaign/forms.py
@@ -104,7 +104,7 @@ class AudioRecordingForm(Form):
             mime = magic.from_file(tmp.name, mime=True)
         if mime in ["audio/wav", "audio/x-wav"] and field.data.mimetype == "audio/wav":
             return True
-        if mime in ["audio/mp3", "audio/mpeg"] and field.data.mimetype == "audio/mp3":
+        if mime in ["audio/mp3", "audio/mpeg"] and field.data.mimetype in ["audio/mp3", "audio/mpeg"]:
             return True
         raise ValidationError("File type must be mp3 or wav, got {}.".format(mime))
 


### PR DESCRIPTION
Firefox is uploading mp3s with content type audio/mpeg.