### PR TITLE
Use Debian latest as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:xenial
-RUN apt-get update && apt-get -y install python-pip python-dev npm git uwsgi libpq-dev curl unzip
+FROM python:2.7-stretch
+RUN apt-get update && \
+  curl -sL https://deb.nodesource.com/setup_4.x | bash && \
+  apt-get -y install git uwsgi libpq-dev curl unzip nodejs
 
 RUN  mkdir /ngrok && \
      cd /ngrok && \
@@ -9,12 +11,6 @@ RUN  mkdir /ngrok && \
 
 WORKDIR /opt
 
-# We need to remove the os version of setuptools
-# It's incompatible with a dependency in gevent-psycopg2
-RUN easy_install -m setuptools
-RUN rm -r /usr/lib/python2.7/dist-packages/setuptools*
-RUN pip install setuptools
-
 ADD requirements.txt ./
 ADD requirements ./requirements
 RUN pip install -r requirements/production.txt -r requirements/development.txt
@@ -22,7 +18,6 @@ RUN pip install -r requirements/production.txt -r requirements/development.txt
 ADD bower.json ./
 ADD .bowerrc ./
 RUN npm install -g bower
-RUN ln -s /usr/bin/nodejs /usr/bin/node
 RUN bower --allow-root --config.interactive=false install
 
 ADD alembic.ini manager.py Procfile uwsgi.ini entrypoint.sh ./

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,9 +1,6 @@
 -r common.txt
 boto==2.38.0
-gevent==1.1.1
-psycogreen==1.0
-greenlet==0.4.10
 psycopg2==2.8.2
 redis==2.10.3
-uWSGI==2.0.14
+uWSGI==2.0.15
 raven==4.0.4


### PR DESCRIPTION
This, along with upgrade to uwsgi 2.0.15, gives us openssl 1.1.0.

This PR also removes unused prod dependencies for threading within workers.