### PR TITLE
Upgrade psycopg2 to 2.8.6 to support PostgreSQL 13+

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,7 +3,7 @@ boto==2.38.0
 gevent==1.1.1
 psycogreen==1.0
 greenlet==0.4.10
-psycopg2==2.8.2
+psycopg2==2.8.6
 redis==2.10.3
 uWSGI==2.0.15
 raven==4.0.4


### PR DESCRIPTION
Should support to at least PostgreSQL 14, and our current version of PostgreSQL 12 is out of date.