### PR TITLE
Update Sentry client from Raven

### DIFF
--- a/call_server/app.py
+++ b/call_server/app.py
@@ -1,6 +1,22 @@
 import os
 import logging
 
+if os.environ.get('SENTRY_DSN'):
+    import sentry_sdk # must be loaded before Flask
+
+    sentry_sdk.init(
+        dsn=os.environ.get('SENTRY_DSN'),
+        environment=os.environ.get('SENTRY_ENVIRONMENT'),
+        send_default_pii=False,
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for tracing.
+        traces_sample_rate=float(os.environ.get('SENTRY_TRACES_SAMPLE_RATE')),
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # We recommend adjusting this value in production.
+        profiles_sample_rate=float(os.environ.get('SENTRY_PROFILES_SAMPLE_RATE')),
+    )
+
 from flask import Flask, g, request, session
 from flask.ext.assets import Bundle
 

--- a/call_server/wsgi.py
+++ b/call_server/wsgi.py
@@ -19,9 +19,4 @@ application = create_app()
 # requires application context
 assets.auto_build = False
 
-if os.environ.get('SENTRY_DSN'):
-    from raven.contrib.flask import Sentry
-    sentry = Sentry()
-    sentry.init_app(application)
-
 application.wsgi_app = ProxyFix(application.wsgi_app)

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -16,5 +16,8 @@ services:
       CALLPOWER_CONFIG: call_server.config:DevelopmentConfig # or call_server.config:ProductionConfig
       APP_HOST: 0.0.0.0
       SENTRY_DSN: # optional, for logging errors to Sentry
+      SENTRY_ENVIRONMENT: # optional, for logging errors to Sentry
+      SENTRY_TRACES_SAMPLE_RATE: # optional, for logging errors to Sentry
+      SENTRY_PROFILES_SAMPLE_RATE: # optional, for logging errors to Sentry
     ports:
       - "5000:5000"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -43,3 +43,4 @@ unittest2==0.5.1
 validators==0.7
 webassets==0.10.1
 wsgiref==0.1.2
+sentry-sdk==1.45.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,4 +6,3 @@ greenlet==0.4.10
 psycopg2==2.8.2
 redis==2.10.3
 uWSGI==2.0.15
-raven==4.0.4


### PR DESCRIPTION
* Moves sentry dependency to common requirements file, so we can test in all envs
* Makes sure we load Sentry before Flask, per Sentry docs
* Passes environment variables used to configure Sentry in docker-compose.yml

Note: this should gracefully handle profiling and trace rates being unset, but will break if a non-float value is entered. Could be better handled in future, but seemed okay for now.

Tested locally by updating docker-compose.yml with following:
```
      SENTRY_DSN: <DSN>
      SENTRY_ENVIRONMENT: development
      SENTRY_TRACES_SAMPLE_RATE: 1.0
      SENTRY_PROFILES_SAMPLE_RATE: 1.0
```
which resulted in [this error](https://electronic-frontier-56e6dfa7d.sentry.io/issues/6338488717/?project=4508876802818048&query=&referrer=issue-stream&statsPeriod=30d&stream_index=0) and [this trace](https://electronic-frontier-56e6dfa7d.sentry.io/traces/trace/6c13f25a5339410a9ae67769ed06e8a6/?environment=production&pageEnd&pageStart&project=4508876752748544&source=traces&statsPeriod=30d&timestamp=1740694739.139)